### PR TITLE
Added dependencies for CentOS/RHEL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ Move into the lib\_mysqludf\_ssdeep directory.
 
 #### MySQL Libraries
 
-	yum install gcc-c++ mysql-devel
+	yum install gcc-c++ mysql-devel autoconf automake
 
 #### ssdeep Libraries
 


### PR DESCRIPTION
The buildtools also need autoconf and automake on CentOS (and probably RHEL as well)
