### PR TITLE
Added dependencies for CentOS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ Move into the lib\_mysqludf\_ssdeep directory.
 
 #### MySQL Libraries
 
-	yum install gcc-c++ mysql-devel autoconf automake
+	yum install gcc-c++ mysql-devel autoconf automake libtools
 
 #### ssdeep Libraries
 

--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ Move into the lib\_mysqludf\_ssdeep directory.
 
 #### MySQL Libraries
 
-	yum install gcc-c++ mysql-devel
+	yum install gcc-c++ mysql-devel autoconf automake
 
 #### ssdeep Libraries
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,7 +25,7 @@ Redhat
 
 To install the GCC C++ compiler and the MySQL development headers install the following packages::
 
-    $ yum install gcc-c++ mysql-devel
+    $ yum install gcc-c++ mysql-devel autoconf automake libtools
 
 As there is no libfuzzy package on Redhat you need to build ssdeep from `its sources`_::
 


### PR DESCRIPTION
In CentOS/RHEL, by default libtools, autoconf and automake are not installed, I added these dependencies. Yum will figure out if they need to be installed.
