### PR TITLE
Added dependencies for CentOS/RHEL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ Move into the lib\_mysqludf\_ssdeep directory.
 
 #### MySQL Libraries
 
-	yum install gcc-c++ mysql-devel
+	yum install gcc-c++ mysql-devel autoconf automake libtool
 
 #### ssdeep Libraries
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,7 +25,7 @@ Redhat
 
 To install the GCC C++ compiler and the MySQL development headers install the following packages::
 
-    $ yum install gcc-c++ mysql-devel
+    $ yum install gcc-c++ mysql-devel autoconf automake libtool
 
 As there is no libfuzzy package on Redhat you need to build ssdeep from `its sources`_::
 


### PR DESCRIPTION
CentOS (and probably RHEL as well), doesn't have libtool, autoconf and automake installed by default, I added them to the readme for clarification.
